### PR TITLE
Fixed bug in nextcloud auth

### DIFF
--- a/app/src/main/kotlin/ac/mdiq/podcini/preferences/fragments/SynchronizationPreferencesFragment.kt
+++ b/app/src/main/kotlin/ac/mdiq/podcini/preferences/fragments/SynchronizationPreferencesFragment.kt
@@ -285,6 +285,8 @@ class SynchronizationPreferencesFragment : PreferenceFragmentCompat() {
         }
         override fun onResume() {
             super.onResume()
+            nextcloudLoginFlow?.onResume()
+
             if (shouldDismiss) dismiss()
         }
         override fun onNextcloudAuthenticated(server: String, username: String, password: String) {


### PR DESCRIPTION
The issue was that the browser intent runs on its own thread and so the poll() method is called without waiting for the browser activity to finish. So as the token is not authenticated yet, this leads to the 404. I moved this call to poll() to a method that is called when the app resumes after the browser is finished. 
All my tests work now, so this resolves #49 
