### PR TITLE
chore: crowdin.yml make Fastlane metadata translatable

### DIFF
--- a/crowdin.yml
+++ b/crowdin.yml
@@ -1,10 +1,7 @@
 files:
   - source: /app/src/main/res/values/strings.xml
-    translation: /app/src/main/res/values-%two_letters_code%/%original_file_name%
-    languages_mapping:
-      two_letters_code:
-        id: in
+    translation: /app/src/main/res/values-%android_code%/%original_file_name%
+    translate_content: 0
     translate_attributes: 0
-    update_option: update_as_unapproved
-  - source: fastlane/metadata/android/en-US/*.txt
-    translation: fastlane/metadata/android/%two_letters_code%/%original_file_name%
+  - source: /fastlane/metadata/android/en-US/*.txt
+    translation: /fastlane/metadata/android/%locale%/%original_file_name%

--- a/crowdin.yml
+++ b/crowdin.yml
@@ -6,3 +6,5 @@ files:
         id: in
     translate_attributes: 0
     update_option: update_as_unapproved
+  - source: fastlane/metadata/android/en-US/*.txt
+    translation: fastlane/metadata/android/%two_letters_code%/%original_file_name%


### PR DESCRIPTION
To make the app description translatable the files inside of the `fastlane` directory needs to be added in Crowdin.
During the next release the F-Droid will peak the new translations.

BTW other apps use `%android_code%` for the `values-*` like here:
```yaml
files:
  - source: /app/src/main/res/values/strings.xml
    translation: /app/src/main/res/values-%android_code%/%original_file_name%
  - source: /app/src/main/res/raw/orgzly_getting_started.org
    translation: /app/src/main/res/raw-%android_code%/%original_file_name%
```